### PR TITLE
load: make sure function returns on await

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -259,7 +259,7 @@ export default class LNC {
                 '--onauthdata=onAuthData'
             ];
 
-            await this.go.run(result.instance);
+            this.go.run(result.instance);
             await WebAssembly.instantiate(result.module, this.go.importObject);
         } catch {
             throw new Error('The password provided is not valid.');


### PR DESCRIPTION
If setting up your connecting and awaiting for `load` to complete before calling `connect`, you would not be able to proceed.

This was one of the pain points that were reported to us in the initial alpha release.