### PR TITLE
lightning-node-connect: wasm: pass keys in as parameters to ConnectServer

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -91,7 +91,7 @@ export default class LNC {
     };
 
     _serverHost: string;
-    _pairingPhrase: string;
+    _pairingPhrase?: string;
     _localKey?: string;
     _remoteKey?: string;
     _wasmClientCode: any;
@@ -110,7 +110,7 @@ export default class LNC {
     constructor(config: LncConstructor) {
         this._serverHost =
             config.serverHost || 'mailbox.terminal.lightning.today:443';
-        this._pairingPhrase = config.pairingPhrase || '';
+        this._pairingPhrase = config.pairingPhrase;
         this._localKey = config.localKey;
         this._remoteKey = config.remoteKey;
         this._wasmClientCode =
@@ -123,6 +123,7 @@ export default class LNC {
         this.salt = '';
         this.testCipher = '';
 
+        // load salt and testCipher from localStorage or generate new ones
         if (localStorage.getItem(`lnc-web:${this._namespace}:salt`)) {
             this.salt =
                 localStorage.getItem(`lnc-web:${this._namespace}:salt`) || '';
@@ -140,6 +141,16 @@ export default class LNC {
             localStorage.setItem(
                 `lnc-web:${this._namespace}:testCipher`,
                 this.testCipher
+            );
+        }
+
+        // save pairingPhrase to localStorage for backwards compatibility
+        if (this._pairingPhrase) {
+            localStorage.setItem(
+                `lnc-web:${this._namespace}:pairingPhrase`,
+                this._password
+                    ? encrypt(this._pairingPhrase, this._password, this.salt)
+                    : this._pairingPhrase
             );
         }
 
@@ -264,8 +275,25 @@ export default class LNC {
      * @returns an object containing the localKey and remoteKey
      */
     loadKeys() {
+        let pairingPhrase = '';
         let localKey = '';
         let remoteKey = '';
+
+        if (this._pairingPhrase) {
+            pairingPhrase = this._pairingPhrase;
+        } else if (
+            localStorage.getItem(`lnc-web:${this._namespace}:pairingPhrase`)
+        ) {
+            const data = localStorage.getItem(
+                `lnc-web:${this._namespace}:pairingPhrase`
+            );
+            if (!verifyTestCipher(this.testCipher, this._password, this.salt)) {
+                throw new Error('Invalid Password');
+            }
+            pairingPhrase = this._password
+                ? decrypt(data, this._password, this.salt)
+                : data;
+        }
 
         if (this._localKey) {
             localKey = this._localKey;
@@ -299,10 +327,11 @@ export default class LNC {
                 : data;
         }
 
+        log.debug('pairingPhrase', pairingPhrase);
         log.debug('localKey', localKey);
         log.debug('remoteKey', remoteKey);
 
-        return { localKey, remoteKey };
+        return { pairingPhrase, localKey, remoteKey };
     }
 
     /**
@@ -311,10 +340,7 @@ export default class LNC {
      * @param phrase the pairing phrase
      * @returns a promise that resolves when the connection is established
      */
-    async connect(
-        server: string = this._serverHost,
-        phrase: string = this._pairingPhrase
-    ) {
+    async connect(server: string = this._serverHost) {
         // do not attempt to connect multiple times
         if (this.isConnected) return;
 
@@ -323,13 +349,13 @@ export default class LNC {
         // ensure the WASM binary is loaded
         if (!this.isReady) await this.waitTilReady();
 
-        const { localKey, remoteKey } = this.loadKeys();
+        const { pairingPhrase, localKey, remoteKey } = this.loadKeys();
 
         // connect to the server
         this.wasmNamespace.wasmClientConnectServer(
             server,
             false,
-            phrase,
+            pairingPhrase,
             localKey,
             remoteKey
         );


### PR DESCRIPTION
Related lightning-node-connect PR: https://github.com/lightninglabs/lightning-node-connect/pull/42/files

This PR also adds backwards compatibility for older versions of `litd` by saving the user's `pairingPhrase` to local storage