### PR TITLE
lnc: fix error when calling connect after run

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -405,10 +405,12 @@ export default class LNC {
         // do not attempt to connect multiple times
         if (this.isConnected) return;
 
-        await this.run();
-
+        
         // ensure the WASM binary is loaded
-        if (!this.isReady) await this.waitTilReady();
+        if (!this.isReady) {
+            await this.run();
+            await this.waitTilReady();
+        }
 
         const { pairingPhrase, localKey, remoteKey } = this.loadKeys();
 


### PR DESCRIPTION
Closes #30 

This PR fixes the error when calling `connect` after calling `run`.