### PR TITLE
api: do not convert subscription requests to GRPC objects

### DIFF
--- a/lib/api/lnd/index.ts
+++ b/lib/api/lnd/index.ts
@@ -1,6 +1,4 @@
 import * as LND from '../../types/generated/lightning_pb';
-import * as InvoicesRPC from '../../types/generated/invoicesrpc/invoices_pb';
-import * as RouterRPC from '../../types/generated/routerrpc/router_pb';
 
 import { Lightning } from '../../types/generated/lightning_pb_service';
 import { WalletUnlocker } from '../../types/generated/walletunlocker_pb_service';
@@ -58,11 +56,9 @@ class LndApi extends BaseApi<LndEvents> {
                 callback: (data: any) => void,
                 errCallback?: (data: any) => void
             ): void => {
-                const req = new InvoicesRPC.SubscribeSingleInvoiceRequest();
-                if (request.r_hash) req.setRHash(request.r_hash);
                 this.subscribe(
                     Invoices.SubscribeSingleInvoice,
-                    req,
+                    request,
                     callback,
                     errCallback
                 );
@@ -75,34 +71,9 @@ class LndApi extends BaseApi<LndEvents> {
                 callback: (data: any) => void,
                 errCallback?: (data: any) => void
             ): void => {
-                const chanPoint = new LND.ChannelPoint();
-                if (
-                    request.channel_point &&
-                    request.channel_point.funding_txid_str
-                )
-                    chanPoint.setFundingTxidStr(
-                        request.channel_point.funding_txid_str
-                    );
-                if (
-                    request.channel_point &&
-                    request.channel_point.funding_txid_bytes
-                )
-                    chanPoint.setFundingTxidBytes(
-                        request.channel_point.funding_txid_bytes
-                    );
-                chanPoint.setOutputIndex(request.channel_point.output_index);
-
-                const req = new LND.CloseChannelRequest();
-                req.setChannelPoint(chanPoint);
-                if (request.force) req.setForce(true);
-                if (request.target_conf) req.setTargetConf(request.target_conf);
-                if (request.delivery_address)
-                    req.setDeliveryAddress(request.delivery_address);
-                if (request.sat_per_vbyte)
-                    req.setSatPerVbyte(request.sat_per_vbyte);
                 this.subscribe(
                     Lightning.CloseChannel,
-                    req,
+                    request,
                     callback,
                     errCallback
                 );
@@ -114,7 +85,7 @@ class LndApi extends BaseApi<LndEvents> {
             ): void => {
                 this.subscribe(
                     Lightning.SubscribeChannelBackups,
-                    new LND.ChannelBackupSubscription(),
+                    request,
                     callback,
                     errCallback
                 );
@@ -126,7 +97,7 @@ class LndApi extends BaseApi<LndEvents> {
             ): void => {
                 this.subscribe(
                     Lightning.SubscribeChannelEvents,
-                    new LND.ChannelEventSubscription(),
+                    request,
                     callback,
                     errCallback
                 );
@@ -138,7 +109,7 @@ class LndApi extends BaseApi<LndEvents> {
             ): void => {
                 this.subscribe(
                     Lightning.SubscribeChannelGraph,
-                    new LND.GraphTopologySubscription(),
+                    request,
                     callback,
                     errCallback
                 );
@@ -150,7 +121,7 @@ class LndApi extends BaseApi<LndEvents> {
             ): void => {
                 this.subscribe(
                     Lightning.SubscribeCustomMessages,
-                    new LND.SubscribeCustomMessagesRequest(),
+                    request,
                     callback,
                     errCallback
                 );
@@ -160,13 +131,9 @@ class LndApi extends BaseApi<LndEvents> {
                 callback: (data: any) => void,
                 errCallback?: (data: any) => void
             ): void => {
-                const req = new LND.InvoiceSubscription();
-                if (request.add_index) req.setAddIndex(request.add_index);
-                if (request.settle_index)
-                    req.setSettleIndex(request.settle_index);
                 this.subscribe(
                     Lightning.SubscribeInvoices,
-                    req,
+                    request,
                     callback,
                     errCallback
                 );
@@ -178,7 +145,7 @@ class LndApi extends BaseApi<LndEvents> {
             ): void => {
                 this.subscribe(
                     Lightning.SubscribePeerEvents,
-                    new LND.PeerEventSubscription(),
+                    request,
                     callback,
                     errCallback
                 );
@@ -188,14 +155,9 @@ class LndApi extends BaseApi<LndEvents> {
                 callback: (data: any) => void,
                 errCallback?: (data: any) => void
             ): void => {
-                const req = new LND.GetTransactionsRequest();
-                if (request.start_height)
-                    req.setStartHeight(request.start_height);
-                if (request.end_height) req.setEndHeight(request.end_height);
-                if (request.account) req.setAccount(request.account);
                 this.subscribe(
                     Lightning.SubscribeTransactions,
-                    req,
+                    request,
                     callback,
                     errCallback
                 );
@@ -208,10 +170,9 @@ class LndApi extends BaseApi<LndEvents> {
                 callback: (data: any) => void,
                 errCallback?: (data: any) => void
             ): void => {
-                const req = new RouterRPC.SubscribeHtlcEventsRequest();
                 this.subscribe(
                     Router.SubscribeHtlcEvents,
-                    req,
+                    request,
                     callback,
                     errCallback
                 );
@@ -236,19 +197,17 @@ class LndApi extends BaseApi<LndEvents> {
     connectStreams() {
         this.subscribe(
             Lightning.SubscribeTransactions,
-            new LND.GetTransactionsRequest(),
+            {},
             (transaction: any) =>
                 this.emit('transaction', transaction.toObject())
         );
         this.subscribe(
             Lightning.SubscribeChannelEvents,
-            new LND.ChannelEventSubscription(),
+            {},
             (channelEvent: any) => this.emit('channel', channelEvent.toObject())
         );
-        this.subscribe(
-            Lightning.SubscribeInvoices,
-            new LND.InvoiceSubscription(),
-            (invoiceEvent: any) => this.emit('invoice', invoiceEvent.toObject())
+        this.subscribe(Lightning.SubscribeInvoices, {}, (invoiceEvent: any) =>
+            this.emit('invoice', invoiceEvent.toObject())
         );
     }
 

--- a/lib/api/loop/index.ts
+++ b/lib/api/loop/index.ts
@@ -33,8 +33,12 @@ class LoopApi extends BaseApi<LoopEvents> {
                 callback: (data: any) => void,
                 errCallback?: (data: any) => void
             ): void => {
-                const req = new LOOP.MonitorRequest();
-                this.subscribe(SwapClient.Monitor, req, callback, errCallback);
+                this.subscribe(
+                    SwapClient.Monitor,
+                    request,
+                    callback,
+                    errCallback
+                );
             }
         };
 
@@ -48,7 +52,7 @@ class LoopApi extends BaseApi<LoopEvents> {
     connectStreams() {
         this.subscribe(
             SwapClient.Monitor,
-            new LOOP.MonitorRequest(),
+            {},
             (swapStatus: any) => this.emit('status', swapStatus.toObject())
         );
     }

--- a/lib/api/pool/index.ts
+++ b/lib/api/pool/index.ts
@@ -37,8 +37,7 @@ class PoolApi extends BaseApi<PoolEvents> {
                 callback: (data: any) => void,
                 errCallback?: (data: any) => void
             ): void => {
-                const req = new HASHMAIL.CipherBoxDesc();
-                this.subscribe(HashMail.RecvStream, req, callback, errCallback);
+                this.subscribe(HashMail.RecvStream, request, callback, errCallback);
             }
         };
 

--- a/lib/lnc.ts
+++ b/lib/lnc.ts
@@ -265,8 +265,8 @@ export default class LNC {
         onError?: (res: Error) => void
     ) {
         const method = `${methodDescriptor.service.serviceName}.${methodDescriptor.methodName}`;
-        log.debug(`${method} request`, request.toObject());
-        const hackedReq = this.hackRequest(request.toObject());
+        log.debug(`${method} request`, request);
+        const hackedReq = this.hackRequest(request || {});
         log.debug(`${method} hacked request`, hackedReq);
         const reqJSON = JSON.stringify(hackedReq);
         this.wasm.wasmClientInvokeRPC(method, reqJSON, (response: string) => {


### PR DESCRIPTION
Closes #32 

This PR updates the subscription functions to forward the request objects as-is to the WASM. This fixes the two issues in #32.