### PR TITLE
lnc: fix error when calling connect after run (again)

### DIFF
--- a/demos/kitchen-sink/src/App.js
+++ b/demos/kitchen-sink/src/App.js
@@ -12,6 +12,7 @@ function App() {
   const isConnected = () => console.log(lnc.isConnected);
   const isReady = () => console.log(lnc.isReady);
   const load = () => lnc.preload();
+  const run = () => lnc.run();
   const connect = () => lnc.connect();
   const disconnect = () => lnc.disconnect();
 
@@ -85,6 +86,7 @@ function App() {
         <button onClick={() => isReady()}>isReady</button>
         <button onClick={() => isConnected()}>isConnected</button>
         <button onClick={() => load()}>Load</button>
+        <button onClick={() => run()}>Run</button>
         <button onClick={() => connect()}>Connect</button>
         <button onClick={() => disconnect()}>Disconnect</button>
         <h1>LND</h1>

--- a/lib/lnc.ts
+++ b/lib/lnc.ts
@@ -138,10 +138,11 @@ export default class LNC {
         // do not attempt to connect multiple times
         if (this.isConnected) return;
 
-        await this.run();
-
         // ensure the WASM binary is loaded
-        if (!this.isReady) await this.waitTilReady();
+        if (!this.isReady) {
+            await this.run();
+            await this.waitTilReady();
+        }
 
         const { pairingPhrase, localKey, remoteKey, serverHost } =
             this.credentials;


### PR DESCRIPTION
I'm not sure what happened but it looks like I accidentally reverted #31 in my refactoring PR. I ran into the bug #30 again when calling `connect` after calling `run`. This PR fixes the bug.

I also added a "Run" button to the kitchen-sink demo for easier testing