### PR TITLE
lnc: return Error object in rejected promises

### DIFF
--- a/lib/lnc.ts
+++ b/lib/lnc.ts
@@ -203,7 +203,9 @@ export default class LNC {
                 } else if (counter > 20) {
                     clearInterval(interval);
                     reject(
-                        'Failed to connect the WASM client to the proxy server'
+                        new Error(
+                            'Failed to connect the WASM client to the proxy server'
+                        )
                     );
                 }
             }, 500);
@@ -231,7 +233,7 @@ export default class LNC {
                     log.info('The WASM client is ready');
                 } else if (counter > 20) {
                     clearInterval(interval);
-                    reject('Failed to load the WASM client');
+                    reject(new Error('Failed to load the WASM client'));
                 }
             }, 500);
         });


### PR DESCRIPTION
This is a minor fix to always return `Error` objects when rejecting a `Promise`. We want to be consistent with these so that consumers of the package properly handle the errors in try/catch blocks. 