### PR TITLE
remove global window and localStorage dependecy

### DIFF
--- a/lib/lnc.ts
+++ b/lib/lnc.ts
@@ -65,7 +65,7 @@ export default class LNC {
     }
 
     private get wasm() {
-        return window[this._namespace] as WasmGlobal;
+        return globalThis[this._namespace] as WasmGlobal;
     }
 
     get isReady() {
@@ -195,7 +195,11 @@ export default class LNC {
         );
 
         // add an event listener to disconnect if the page is unloaded
-        window.addEventListener('unload', this.wasm.wasmClientDisconnect);
+        if (typeof window !== "undefined") {
+            window.addEventListener('unload', this.wasm.wasmClientDisconnect);
+        } else {
+            log.info("No unload event listener added. window is not available");
+        }
 
         // repeatedly check if the connection was successful
         return new Promise<void>((resolve, reject) => {

--- a/lib/util/encryption.ts
+++ b/lib/util/encryption.ts
@@ -6,7 +6,7 @@ export const generateSalt = () => {
     const validChars =
         'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
     let array = new Uint8Array(32);
-    window.crypto.getRandomValues(array);
+    globalThis.crypto.getRandomValues(array);
     array = array.map((x) => validChars.charCodeAt(x % validChars.length));
     const salt = String.fromCharCode.apply(null, array as any);
     return salt;

--- a/lib/util/log.ts
+++ b/lib/util/log.ts
@@ -27,9 +27,9 @@ export class Logger {
         // by default, log nothing (assuming prod)
         let level = LogLevel.none;
 
-        if (localStorage && localStorage.getItem('debug')) {
+        if (globalThis.localStorage && globalThis.localStorage.getItem('debug')) {
             // if a 'debug' key is found in localStorage, use the level in storage or 'debug' by default
-            const storageLevel = localStorage.getItem('debug-level') || 'debug';
+            const storageLevel = globalThis.localStorage.getItem('debug-level') || 'debug';
             level = LogLevel[storageLevel as keyof typeof LogLevel];
         }
 


### PR DESCRIPTION
window and localStorage are not available in all environments. For example service workers don't have those available (afaik). 
The globalThis property provides a standard way of accessing the global this value across environments.

The wasm_exec.js code already checks if window is available. 

reference:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis