### PR TITLE
lib: add LitApi to LNC

### DIFF
--- a/lib/lnc.ts
+++ b/lib/lnc.ts
@@ -1,5 +1,6 @@
 import {
     FaradayApi,
+    LitApi,
     LndApi,
     LoopApi,
     PoolApi,
@@ -32,6 +33,7 @@ export default class LNC {
     loop: LoopApi;
     pool: PoolApi;
     faraday: FaradayApi;
+    lit: LitApi;
 
     constructor(lncConfig?: LncConfig) {
         // merge the passed in config with the defaults
@@ -62,6 +64,7 @@ export default class LNC {
         this.loop = new LoopApi(createRpc, this);
         this.pool = new PoolApi(createRpc, this);
         this.faraday = new FaradayApi(createRpc, this);
+        this.lit = new LitApi(createRpc, this);
     }
 
     private get wasm() {

--- a/lib/lnc.ts
+++ b/lib/lnc.ts
@@ -12,7 +12,7 @@ import { wasmLog as log } from './util/log';
 
 /** The default values for the LncConfig options */
 const DEFAULT_CONFIG = {
-    wasmClientCode: 'https://lightning.engineering/lnc-v0.2.2-alpha.wasm',
+    wasmClientCode: 'https://lightning.engineering/lnc-v0.2.3-alpha.wasm',
     namespace: 'default',
     serverHost: 'mailbox.terminal.lightning.today:443'
 } as Required<LncConfig>;

--- a/lib/util/credentialStore.ts
+++ b/lib/util/credentialStore.ts
@@ -189,6 +189,9 @@ export default class LncCredentialStore implements CredentialStore {
 
     /** Loads persisted data from localStorage */
     private _load() {
+        // do nothing if localStorage is not available
+        if (typeof localStorage === 'undefined') return;
+
         try {
             const key = `${STORAGE_KEY}:${this.namespace}`;
             const json = localStorage.getItem(key);
@@ -202,6 +205,9 @@ export default class LncCredentialStore implements CredentialStore {
 
     /** Saves persisted data to localStorage */
     private _save() {
+        // do nothing if localStorage is not available
+        if (typeof localStorage === 'undefined') return;
+
         const key = `${STORAGE_KEY}:${this.namespace}`;
         localStorage.setItem(key, JSON.stringify(this.persisted));
     }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "webpack-cli": "4.9.2"
   },
   "dependencies": {
-    "@lightninglabs/lnc-core": "0.2.2-alpha",
+    "@lightninglabs/lnc-core": "0.2.3-alpha",
     "crypto-js": "4.1.1"
   },
   "browser": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,7 @@ module.exports = {
       name: '@lightninglabs/lnc-web',
       type: "umd",  // see https://webpack.js.org/configuration/output/#outputlibrarytype
     },
+    globalObject: 'this',
     path: path.resolve(__dirname, 'dist'),
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,10 +80,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@lightninglabs/lnc-core@0.2.2-alpha":
-  version "0.2.2-alpha"
-  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-core/-/lnc-core-0.2.2-alpha.tgz#37e1dcf3419844f70e5df7901ec55cb62a9b0b1e"
-  integrity sha512-S46tZ6cH7jPgrotbZS9Pceyb2Nf+gaC9gmorm1DC7OpWxaf2gilelNk+0wVf9B8pqIwnBfr1z3h/sTophvLkUQ==
+"@lightninglabs/lnc-core@0.2.3-alpha":
+  version "0.2.3-alpha"
+  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-core/-/lnc-core-0.2.3-alpha.tgz#e1b92a9071d1dfb92e2d565710b56f28f57cbbd4"
+  integrity sha512-93D/uU64ayAaJv5kv4Pqwvkt+uT7yCtmHD08aUzvql+lbWm6U7m5loZLxz7tACFLXVPOQ8OHJL25W+3QMEYthg==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"


### PR DESCRIPTION
This PR adds a `lnc.lit` field to provide access to the `litd` RPCs exposed by `lnc-core` in https://github.com/lightninglabs/lnc-core/pull/13.

I also made a few small changes to fix issues found when running this package in a server-side rendering environment. 