### PR TITLE
lnc+util: assign WASM callbacks to a namespaced scope

### DIFF
--- a/lib/types/lnc.ts
+++ b/lib/types/lnc.ts
@@ -48,6 +48,25 @@ export interface WasmGlobal {
      * Returns the WASM client expiry time
      */
     wasmClientGetExpiry: () => number;
+    /**
+     * The callback that is called when the WASM client generates a new local private
+     * key. This is used to reestablish subsequent connections to the proxy server.
+     * @param keyHex the hex encoded private key of the local WASM client
+     */
+    onLocalPrivCreate?: (keyHex: string) => void;
+    /**
+     * The callback that is called when the WASM client receives the remote node's
+     * public key. This is used to reestablish subsequent connections to the proxy
+     * server.
+     * @param keyHex the hex encoded public key of the remote node
+     */
+    onRemoteKeyReceive?: (keyHex: string) => void;
+    /**
+     * The callback that is called when the WASM client receives the macaroon
+     * associated with the LNC session.
+     * @param macaroonHex the hex encoded macaroon associated with the LNC session
+     */
+    onAuthData?: (macaroonHex: string) => void;
 }
 
 export interface LncConfig {

--- a/lib/util/credentialStore.ts
+++ b/lib/util/credentialStore.ts
@@ -43,10 +43,14 @@ export default class LncCredentialStore implements CredentialStore {
      */
     constructor(namespace?: string, password?: string) {
         if (namespace) this.namespace = namespace;
-        if (password) this.password = password;
 
         // load data stored in localStorage
         this._load();
+
+        // set the password after loading the data, otherwise the data will be
+        // overwritten because the password setter checks for the existence of
+        // persisted data.
+        if (password) this.password = password;
     }
 
     //


### PR DESCRIPTION
This PR updates the LNC class to no longer use the JS `global` object for the callbacks from the WASM client. The callbacks  functions will now be nested under an object using the `namespace` as a name. So if the app uses `new LNC({ namespace: 'myapp' });`, the callbacks will be created on the `global.myapp` object instead of previously being on `global`.

This depends on https://github.com/lightninglabs/lightning-node-connect/pull/72 which has been merged into the `master` branch. 

### Steps to test with the kitchen-sink demo:

1. Clone the [lightning-node-connect](https://github.com/lightninglabs/lightning-node-connect) repo
2. Run `make wasm` to produce the WASM binary
3. Checkout this PR branch in the `lnc-web` repo
4. Copy `lightning-node-connect/example/wasm-client.wasm` into `lnc-web/demos/kitchen-sink/public/`
5. Update `kitchen-sink/src/App.js` to use the new WASM binary and your own pairing phrase and namespace
    ```js
      const lnc = new LNC({
         namespace: 'myapp',
         pairingPhrase: 'iron boss window awful list bag crucial mixture useless piano',
         password: 'Dm9lfaWmo92Q#m9f',
         wasmClientCode: '/lnc-5903579.wasm',
      });
    ```
6. Ensure that the kitchen-sink demo is using this branch of the `lnc-web` code. Then start the app
   ```js
   $ cd demos/kitchen-sink/
   $ yarn
   $ yarn add ../..
   $ yarn start
   ```
7. In the browser, click on the "Connect" button and confirm the connection is successful by clicking on `getInfo`
8. In the console, confirm that `window.onLocalPrivCreate` is `undefined` and that `typeof window.myapp.onLocalPrivCreate` is `function`

_Note: This PR also fixes an issue in the `credentialStore` where it was overwriting the data on every page reload in the kitchen-sink demo. This was due to the password being provided in the constructor._