### PR TITLE
deps: update lnc-core to v0.2.4-alpha

### DIFF
--- a/lib/lnc.ts
+++ b/lib/lnc.ts
@@ -13,7 +13,7 @@ import { wasmLog as log } from './util/log';
 
 /** The default values for the LncConfig options */
 const DEFAULT_CONFIG = {
-    wasmClientCode: 'https://lightning.engineering/lnc-v0.2.3-alpha.wasm',
+    wasmClientCode: 'https://lightning.engineering/lnc-v0.2.4-alpha.wasm',
     namespace: 'default',
     serverHost: 'mailbox.terminal.lightning.today:443'
 } as Required<LncConfig>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightninglabs/lnc-web",
-  "version": "0.2.3-alpha",
+  "version": "0.2.4-alpha",
   "description": "Lightning Node Connect npm module for web",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "webpack-cli": "4.9.2"
   },
   "dependencies": {
-    "@lightninglabs/lnc-core": "0.2.3-alpha",
+    "@lightninglabs/lnc-core": "0.2.4-alpha",
     "crypto-js": "4.1.1"
   },
   "browser": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,10 +80,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@lightninglabs/lnc-core@0.2.3-alpha":
-  version "0.2.3-alpha"
-  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-core/-/lnc-core-0.2.3-alpha.tgz#e1b92a9071d1dfb92e2d565710b56f28f57cbbd4"
-  integrity sha512-93D/uU64ayAaJv5kv4Pqwvkt+uT7yCtmHD08aUzvql+lbWm6U7m5loZLxz7tACFLXVPOQ8OHJL25W+3QMEYthg==
+"@lightninglabs/lnc-core@0.2.4-alpha":
+  version "0.2.4-alpha"
+  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-core/-/lnc-core-0.2.4-alpha.tgz#3864ea91cd57d3340ed250cdff9318ba6dbcfe6e"
+  integrity sha512-vZQJzMB5tWW/GFxUFyxrfDAGM8Q4jz55vjO4IJyp9Pk8fxBeYEyYJYF8+cJ9/9CKZ7fgX9MPp8m08oOVjJVlhQ==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"


### PR DESCRIPTION
Update to use `lnc-core` v0.2.4-alpha.

Also, bumps the version of `lnc-web` to v0.2.4-alpha.