### PR TITLE
lib: clear in-memory credentials after connection

### DIFF
--- a/lib/lnc.ts
+++ b/lib/lnc.ts
@@ -229,6 +229,12 @@ export default class LNC {
                     clearInterval(interval);
                     resolve();
                     log.info('The WASM client is connected to the server');
+
+                    // clear the in-memory credentials after connecting if the
+                    // credentials are persisted in local storage
+                    if (this.credentials.password) {
+                        this.credentials.clear(true);
+                    }
                 } else if (counter > 20) {
                     clearInterval(interval);
                     reject(

--- a/lib/types/lnc.ts
+++ b/lib/types/lnc.ts
@@ -132,6 +132,11 @@ export interface CredentialStore {
      * credentials persisted in the store
      */
     isPaired: boolean;
-    /** Clears any persisted data in the store */
-    clear(): void;
+    /**
+     * Clears the in-memory and persisted data in the store.
+     * @param memoryOnly If `true`, only the in-memory data will be cleared. If
+     * `false` or `undefined`, the persisted data will be cleared as well.
+     * The default is `undefined`.
+     */
+    clear(memoryOnly?: boolean): void;
 }

--- a/lib/util/credentialStore.ts
+++ b/lib/util/credentialStore.ts
@@ -105,6 +105,10 @@ export default class LncCredentialStore implements CredentialStore {
             if (this.remoteKey)
                 this.persisted.remoteKey = this._encrypt(this.remoteKey);
             this._save();
+
+            // once the encrypted data is persisted, we can clear the plain text
+            // credentials from memory
+            this.clear(true);
         }
     }
 
@@ -170,9 +174,11 @@ export default class LncCredentialStore implements CredentialStore {
     }
 
     /** Clears any persisted data in the store */
-    clear() {
-        const key = `${STORAGE_KEY}:${this.namespace}`;
-        localStorage.removeItem(key);
+    clear(memoryOnly?: boolean) {
+        if (!memoryOnly) {
+            const key = `${STORAGE_KEY}:${this.namespace}`;
+            localStorage.removeItem(key);
+        }
         this.persisted = {
             salt: '',
             cipher: '',


### PR DESCRIPTION
Since the credentials used to start LNC are no longer needed after the connection is established and the encrypted data is persisted to local storage, we can clear this data from memory.