### PR TITLE
Bump lnc-core version and add Taproot Assets support

### DIFF
--- a/demos/kitchen-sink/src/App.js
+++ b/demos/kitchen-sink/src/App.js
@@ -20,6 +20,7 @@ function App() {
   const { swapClient } = lnc.loop;
   const { trader } = lnc.pool;
   const { faradayServer } = lnc.faraday;
+  const { taprootAssets, mint, universe, assetWallet } = lnc.tapd;
 
   // LND
 
@@ -79,6 +80,28 @@ function App() {
       console.log(insights);
   };
 
+  // Taproot Assets
+
+  const listAssets = async() => {
+      const assets = await taprootAssets.listAssets();
+      console.log(assets);
+  };
+
+  const listBatches = async() => {
+      const assets = await mint.listBatches();
+      console.log(assets);
+  };
+
+  const listFederationServers = async() => {
+      const assets = await universe.listFederationServers();
+      console.log(assets);
+  };
+
+  const nextScriptKey = async() => {
+      const assets = await assetWallet.nextScriptKey({ keyFamily: 1 })
+      console.log(assets);
+  };
+
   return (
     <div className="App">
       <header className="App-header">
@@ -103,6 +126,11 @@ function App() {
         <button onClick={() => auctionFee()}>auctionFee</button>
         <h1>Faraday</h1>
         <button onClick={() => channelInsights()}>channelInsights</button>
+        <h1>Taproot Assets</h1>
+        <button onClick={() => listAssets()}>listAssets</button>
+        <button onClick={() => listBatches()}>listBatches</button>
+        <button onClick={() => listFederationServers()}>listFederationServers</button>
+        <button onClick={() => nextScriptKey()}>nextScriptKey</button>
       </header>
     </div>
   );

--- a/lib/lnc.ts
+++ b/lib/lnc.ts
@@ -13,7 +13,7 @@ import { wasmLog as log } from './util/log';
 
 /** The default values for the LncConfig options */
 const DEFAULT_CONFIG = {
-    wasmClientCode: 'https://lightning.engineering/lnc-v0.2.4-alpha.wasm',
+    wasmClientCode: 'https://lightning.engineering/lnc-v0.2.5-alpha.wasm',
     namespace: 'default',
     serverHost: 'mailbox.terminal.lightning.today:443'
 } as Required<LncConfig>;

--- a/lib/lnc.ts
+++ b/lib/lnc.ts
@@ -4,7 +4,8 @@ import {
     LndApi,
     LoopApi,
     PoolApi,
-    snakeKeysToCamel
+    snakeKeysToCamel,
+    TaprootAssetsApi
 } from '@lightninglabs/lnc-core';
 import { createRpc } from './api/createRpc';
 import { CredentialStore, LncConfig, WasmGlobal } from './types/lnc';
@@ -33,6 +34,7 @@ export default class LNC {
     loop: LoopApi;
     pool: PoolApi;
     faraday: FaradayApi;
+    tapd: TaprootAssetsApi;
     lit: LitApi;
 
     constructor(lncConfig?: LncConfig) {
@@ -64,6 +66,7 @@ export default class LNC {
         this.loop = new LoopApi(createRpc, this);
         this.pool = new PoolApi(createRpc, this);
         this.faraday = new FaradayApi(createRpc, this);
+        this.tapd = new TaprootAssetsApi(createRpc, this);
         this.lit = new LitApi(createRpc, this);
     }
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "webpack-cli": "4.9.2"
   },
   "dependencies": {
-    "@lightninglabs/lnc-core": "0.2.4-alpha",
+    "@lightninglabs/lnc-core": "0.2.5-alpha",
     "crypto-js": "4.1.1"
   },
   "browser": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,10 +80,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@lightninglabs/lnc-core@0.2.4-alpha":
-  version "0.2.4-alpha"
-  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-core/-/lnc-core-0.2.4-alpha.tgz#3864ea91cd57d3340ed250cdff9318ba6dbcfe6e"
-  integrity sha512-vZQJzMB5tWW/GFxUFyxrfDAGM8Q4jz55vjO4IJyp9Pk8fxBeYEyYJYF8+cJ9/9CKZ7fgX9MPp8m08oOVjJVlhQ==
+"@lightninglabs/lnc-core@0.2.5-alpha":
+  version "0.2.5-alpha"
+  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-core/-/lnc-core-0.2.5-alpha.tgz#4150b9d8002a8dac582edc6216581feb2b613196"
+  integrity sha512-mdofMCydpNLAf0Abwy81FsuOMIrUqsxR5kZ9Qzjp+E7bZdMntsKY3p0oqq/y3o/6hfrKN7Ornht42Cebc/i9Iw==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"


### PR DESCRIPTION
Updates the default WASM file url to v0.2.5-alpha and exposes the tapd API via the LNC class.

Note: CI will fail until the new version of `lnc-core` is published to NPM.

To test these changes:
1. Checkout https://github.com/lightninglabs/lnc-core/pull/17 and run `yarn && yarn link && yarn build` in that repo
2. Checkout this PR and run `yarn && yarn link @lightninglabs/lnc-core && yarn build` in the root of this repo
3. Change to the `demos/kitchen-sink` dir and run `yarn && yarn link @lightninglabs/lnc-core && yarn start`. The demo site should open in your browser.
4. Grab a pairing phrase from a `litd` node running the `master` branch since https://github.com/lightninglabs/lightning-terminal/pull/572 is needed for the tapd universe RPCs to work.
5. Update `demos/kitchen-sink/src/App.js` with the pairing phrase
6. In the demo site try to Connect and call listAssets to confirm the tapd RPC is functional.