### PR TITLE
deps: ignore demos for dependabot alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      # don't send notifications for demo apps
+      - directory: "demos"
+    # Disable version updates for npm dependencies
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Adds a dependabot config to suppress the alerts for the demo apps.