### PR TITLE
bump version to v0.2.6-alpha

### DIFF
--- a/lib/lnc.ts
+++ b/lib/lnc.ts
@@ -14,7 +14,7 @@ import { wasmLog as log } from './util/log';
 
 /** The default values for the LncConfig options */
 const DEFAULT_CONFIG = {
-    wasmClientCode: 'https://lightning.engineering/lnc-v0.2.5-alpha.wasm',
+    wasmClientCode: 'https://lightning.engineering/lnc-v0.2.6-alpha.wasm',
     namespace: 'default',
     serverHost: 'mailbox.terminal.lightning.today:443'
 } as Required<LncConfig>;

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "webpack-cli": "4.9.2"
   },
   "dependencies": {
-    "@lightninglabs/lnc-core": "0.2.5-alpha",
+    "@lightninglabs/lnc-core": "0.2.6-alpha",
     "crypto-js": "4.1.1"
   },
   "browser": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightninglabs/lnc-web",
-  "version": "0.2.5-alpha",
+  "version": "0.2.6-alpha",
   "description": "Lightning Node Connect npm module for web",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,10 +80,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@lightninglabs/lnc-core@0.2.5-alpha":
-  version "0.2.5-alpha"
-  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-core/-/lnc-core-0.2.5-alpha.tgz#4150b9d8002a8dac582edc6216581feb2b613196"
-  integrity sha512-mdofMCydpNLAf0Abwy81FsuOMIrUqsxR5kZ9Qzjp+E7bZdMntsKY3p0oqq/y3o/6hfrKN7Ornht42Cebc/i9Iw==
+"@lightninglabs/lnc-core@0.2.6-alpha":
+  version "0.2.6-alpha"
+  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-core/-/lnc-core-0.2.6-alpha.tgz#1b93d5aeefb09bb3dedcb82988368b15e223f8fd"
+  integrity sha512-bw2EQG78pPKMZMFwV+TR99RUbYgPVUKQYMLGGKIOvhPds3dBWSDZpMoqOyW/WidWGXF/ugPHzud8lDbKKhNXgA==
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"


### PR DESCRIPTION
This PR bumps the version to `v0.2.6-alpha` and also updates the wasm url to use `v0.2.6-alpha`.