### PR TITLE
bump version to `v0.2.8-alpha`

### DIFF
--- a/lib/lnc.ts
+++ b/lib/lnc.ts
@@ -14,7 +14,7 @@ import { wasmLog as log } from './util/log';
 
 /** The default values for the LncConfig options */
 const DEFAULT_CONFIG = {
-    wasmClientCode: 'https://lightning.engineering/lnc-v0.2.6-alpha.wasm',
+    wasmClientCode: 'https://lightning.engineering/lnc-v0.2.8-alpha.wasm',
     namespace: 'default',
     serverHost: 'mailbox.terminal.lightning.today:443'
 } as Required<LncConfig>;

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "webpack-cli": "4.9.2"
   },
   "dependencies": {
-    "@lightninglabs/lnc-core": "0.2.6-alpha",
+    "@lightninglabs/lnc-core": "0.2.8-alpha",
     "crypto-js": "4.1.1"
   },
   "browser": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightninglabs/lnc-web",
-  "version": "0.2.6-alpha",
+  "version": "0.2.8-alpha",
   "description": "Lightning Node Connect npm module for web",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,10 +80,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@lightninglabs/lnc-core@0.2.6-alpha":
-  version "0.2.6-alpha"
-  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-core/-/lnc-core-0.2.6-alpha.tgz#1b93d5aeefb09bb3dedcb82988368b15e223f8fd"
-  integrity sha512-bw2EQG78pPKMZMFwV+TR99RUbYgPVUKQYMLGGKIOvhPds3dBWSDZpMoqOyW/WidWGXF/ugPHzud8lDbKKhNXgA==
+"@lightninglabs/lnc-core@0.2.8-alpha":
+  version "0.2.8-alpha"
+  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-core/-/lnc-core-0.2.8-alpha.tgz#78272c04a5ec95a9ccb830f75ab9b5ca227f0801"
+  integrity sha512-2tHzmklIiQhJiK1aabX0R2AbbWi0mizWgniCUOb573XToYQN7L61Phh+hWUCxIFfAhHCkp2mnSmX+7eT/ikxOg==
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"


### PR DESCRIPTION
This PR bumps the version to `v0.2.8-alpha` and also updates the wasm url to use `v0.2.8-alpha` + updates the lnc-core dependency to `v0.2.8-alpha`.