### PR TITLE
Do not delete persisted credentials when memoryOnly is used

### DIFF
--- a/lib/util/credentialStore.ts
+++ b/lib/util/credentialStore.ts
@@ -178,15 +178,17 @@ export default class LncCredentialStore implements CredentialStore {
         if (!memoryOnly) {
             const key = `${STORAGE_KEY}:${this.namespace}`;
             localStorage.removeItem(key);
+
+            this.persisted = {
+                salt: '',
+                cipher: '',
+                serverHost: this.persisted.serverHost,
+                localKey: '',
+                remoteKey: '',
+                pairingPhrase: ''
+            };
         }
-        this.persisted = {
-            salt: '',
-            cipher: '',
-            serverHost: this.persisted.serverHost,
-            localKey: '',
-            remoteKey: '',
-            pairingPhrase: ''
-        };
+
         this._localKey = '';
         this._remoteKey = '';
         this._pairingPhrase = '';


### PR DESCRIPTION
Persisted credentials should only be removed when localstorage is being wiped. 

Fixes bug in terminal when multiple nodes are used simultaneously.