### PR TITLE
Bump version to v0.3.1-alpha

### DIFF
--- a/lib/lnc.ts
+++ b/lib/lnc.ts
@@ -14,7 +14,7 @@ import { wasmLog as log } from './util/log';
 
 /** The default values for the LncConfig options */
 const DEFAULT_CONFIG = {
-    wasmClientCode: 'https://lightning.engineering/lnc-v0.3.0-alpha.wasm',
+    wasmClientCode: 'https://lightning.engineering/lnc-v0.3.1-alpha.wasm',
     namespace: 'default',
     serverHost: 'mailbox.terminal.lightning.today:443'
 } as Required<LncConfig>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightninglabs/lnc-web",
-  "version": "0.3.0-alpha",
+  "version": "0.3.1-alpha",
   "description": "Lightning Node Connect npm module for web",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "webpack-cli": "4.9.2"
   },
   "dependencies": {
-    "@lightninglabs/lnc-core": "0.3.0-alpha",
+    "@lightninglabs/lnc-core": "0.3.1-alpha",
     "crypto-js": "4.2.0"
   },
   "browser": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,10 +80,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@lightninglabs/lnc-core@0.3.0-alpha":
-  version "0.3.0-alpha"
-  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-core/-/lnc-core-0.3.0-alpha.tgz#88e4595bb4b1057ef56e6bc106293f283af7b9d6"
-  integrity sha512-I/3KR06jpg2FK+qI4i4IrqFX6hv1V8BlHhJWNV9I2gmo/yQi8B9dNRWRjU1ExBjzJtdf0xlU2Y0maMoI/6ul5A==
+"@lightninglabs/lnc-core@0.3.1-alpha":
+  version "0.3.1-alpha"
+  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-core/-/lnc-core-0.3.1-alpha.tgz#cfd6c0857a20013fb1819b40bd1158a2edc8bcf0"
+  integrity sha512-I/hThdItLWJ6RU8Z27ZIXhpBS2JJuD3+TjtaQXX2CabaUYXlcN4sk+Kx8N/zG/fk8qZvjlRWum4vHu4ZX554Fg==
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"


### PR DESCRIPTION
This PR bumps the version to v0.3.1-alpha and also updates the wasm url to use v0.3.1-alpha.

This PR does not yet update the lnc-core dependency to v0.3.1-alpha, as it has not yet been released. I'll update this PR with a commit that updates the lnc-core dependency as soon as it has been released.