### PR TITLE
Bump version to v0.3.4-alpha

### DIFF
--- a/lib/lnc.ts
+++ b/lib/lnc.ts
@@ -14,7 +14,7 @@ import { wasmLog as log } from './util/log';
 
 /** The default values for the LncConfig options */
 const DEFAULT_CONFIG = {
-    wasmClientCode: 'https://lightning.engineering/lnc-v0.3.3-alpha.wasm',
+    wasmClientCode: 'https://lightning.engineering/lnc-v0.3.4-alpha.wasm',
     namespace: 'default',
     serverHost: 'mailbox.terminal.lightning.today:443'
 } as Required<LncConfig>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightninglabs/lnc-web",
-  "version": "0.3.3-alpha",
+  "version": "0.3.4-alpha",
   "description": "Lightning Node Connect npm module for web",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "webpack-cli": "5.1.4"
   },
   "dependencies": {
-    "@lightninglabs/lnc-core": "0.3.3-alpha",
+    "@lightninglabs/lnc-core": "0.3.4-alpha",
     "crypto-js": "4.2.0"
   },
   "browser": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,10 +85,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@lightninglabs/lnc-core@0.3.3-alpha":
-  version "0.3.3-alpha"
-  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-core/-/lnc-core-0.3.3-alpha.tgz#dd6ec289308b728e743fcc6cc0a9ce64267a5af1"
-  integrity sha512-9azOWE1PJ1D2jPe4k1t5jcVGiGxo1Jsh9LfzmC3NKV+1F70aCwC6L6g24dlgFIoq0ASFkhHDeWUZqVgKVBRKaA==
+"@lightninglabs/lnc-core@0.3.4-alpha":
+  version "0.3.4-alpha"
+  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-core/-/lnc-core-0.3.4-alpha.tgz#0e8cc872c3739158a8480317e76c35679b5d0f72"
+  integrity sha512-S/L1gNHqF8jW3DVXBvzVX8zyJO4O2FRfKFNE5U3rtRBaczX+fSVpK3yz/CdgBqhBzyZ+1un6nVZE/tftnfjQwA==
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"


### PR DESCRIPTION
This PR bumps the version to v0.3.4-alpha and also updates the wasm url to use v0.3.4-alpha.

This PR does not yet update the lnc-core dependency to v0.3.4-alpha, as it has not yet been released. I'll update this PR with a commit that updates the lnc-core dependency as soon as it has been released.

I'm therefore pushing this as draft until lnc-core has been released. As also communicated in the LNC-core PR, I haven't been able to fully test this yet due to issues with my local regtest env. 