### PR TITLE
config: exclude test files from TS build output

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
   ],
   "exclude": [
     "node_modules",
-    "dist"
+    "dist",
+    "**/*.test.ts"
   ]
 }


### PR DESCRIPTION
This is a follow-up to #123. I discovered an issue with the webpack build output. The `index.d.ts` file was being placed at `dist/lib/index.d.ts` instead of `dist/index.d.ts`, which is what the `package.json` defines as the entrypoint for types. This was because the TS test files, that were added in #123, were being included in the output. This is unnecessary and it causes errors when apps like Terminal import this package.

The fix is pretty simple. We just need to exclude `*.test.ts` files from the build output.

Before (wrong):
<img width="362" height="616" alt="image" src="https://github.com/user-attachments/assets/01a58c55-529d-428f-a003-ea3038d29c18" />

After (correct):
<img width="368" height="325" alt="image" src="https://github.com/user-attachments/assets/d69ed365-8a9c-4253-a674-255ef7f46daf" />

## Steps to test

Just run `yarn build` and confirm that the `dist/index.d.ts` file exists and there are no `*.test.d.ts` files in the `dist/`dir.
 