### PR TITLE
Bump version to v0.3.6-alpha

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -18,4 +18,6 @@ jobs:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
       - run: yarn install --frozen-lockfile
-      - run: npm publish
+      # Use the latest tag explicitly. New versions of npm will fail without it
+      # due to our versions having `-alpha` suffixes.
+      - run: npm publish --tag latest

--- a/lib/lightningNodeConnect.ts
+++ b/lib/lightningNodeConnect.ts
@@ -39,7 +39,7 @@ type ResolvedConfig = Required<
 
 /** The default values for the LightningNodeConnectConfig options. */
 export const DEFAULT_CONFIG: LightningNodeConnectConfig = {
-  wasmClientCode: 'https://lightning.engineering/lnc-v0.3.5-alpha.wasm',
+  wasmClientCode: 'https://lightning.engineering/lnc-v0.3.6-alpha.wasm',
   namespace: 'default',
   serverHost: 'mailbox.terminal.lightning.today:443',
   allowPasskeys: true,

--- a/lib/lnc.ts
+++ b/lib/lnc.ts
@@ -13,7 +13,7 @@ import { ConnectionParams, WasmManager } from './wasmManager';
 
 /** The default values for the LncConfig options. */
 export const DEFAULT_CONFIG = {
-  wasmClientCode: 'https://lightning.engineering/lnc-v0.3.5-alpha.wasm',
+  wasmClientCode: 'https://lightning.engineering/lnc-v0.3.6-alpha.wasm',
   namespace: 'default',
   serverHost: 'mailbox.terminal.lightning.today:443'
 } as Required<LncConfig>;

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "webpack-cli": "5.1.4"
   },
   "dependencies": {
-    "@lightninglabs/lnc-core": "0.3.5-alpha",
+    "@lightninglabs/lnc-core": "^0.3.6-alpha",
     "crypto-js": "4.2.0"
   },
   "browser": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightninglabs/lnc-web",
-  "version": "0.3.5-alpha",
+  "version": "0.3.6-alpha",
   "description": "Lightning Node Connect npm module for web",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -351,10 +351,10 @@
   resolved "https://registry.yarnpkg.com/@lightninglabs/ai-docs-sync/-/ai-docs-sync-0.1.0.tgz#6f1fd672d50d0ad00238b0fa7eab8c4496ebda88"
   integrity sha512-u3CRCuMLaFDFvMCQT/aPgNcPYxVy8/bfp/uV8f1Z9C/KSz3YuJYh2KPTonmTen+KV/lm5B3a7kGjKWGYteEE5g==
 
-"@lightninglabs/lnc-core@0.3.5-alpha":
-  version "0.3.5-alpha"
-  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-core/-/lnc-core-0.3.5-alpha.tgz#7874d21eeb1bd01254d96fe5e37da7f06915e810"
-  integrity sha512-20rOA3ZiPxYRCppqLBxXEgaLCoSX4B5L1GTUrvuCaZAU29Ua0Yc1sJrd/A67vNxLOxxWFPkK0jKcSem3ZaGQLQ==
+"@lightninglabs/lnc-core@^0.3.6-alpha":
+  version "0.3.6-alpha"
+  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-core/-/lnc-core-0.3.6-alpha.tgz#43cf66c6134cbc6edfcf55c857cc32c2a9ee825d"
+  integrity sha512-ObzY5wi+PS0GQduFHYDjGJpYZxKD27vtMf3fUVne2gGNMej1mvvJAOwATgef8YV/IZodAzy73Z/F2zfaQ+iE4Q==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"


### PR DESCRIPTION
### Summary

Bumps `lnc-web` to `v0.3.6-alpha`. Updates the package version, WASM client URL, and `lnc-core` dependency to match the new release. Also fixes the npm publish workflow to use `--tag latest` explicitly, which is required for versions with `-alpha` suffixes on newer npm versions.

### Changes

- Package version → `0.3.6-alpha`
- WASM client URL → `lnc-v0.3.6-alpha.wasm` (both `LNC` and `LightningNodeConnect` entrypoints)
- `@lightninglabs/lnc-core` dependency → `^0.3.6-alpha`
- CI: `npm publish` → `npm publish --tag latest` to avoid publish failures on prerelease versions

### Testing

- `yarn install --frozen-lockfile` succeeds with updated lockfile
- `yarn build` compiles cleanly
- Verify npm publish workflow works on next tag push
