### PR TITLE
Bump version to `v0.4.0-alpha`

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,3 +1,3 @@
 /** The default URL for the LNC WASM client binary. */
 export const WASM_CLIENT_URL =
-  'https://lightning.engineering/lnc-v0.3.6-alpha.wasm';
+  'https://lightning.engineering/lnc-v0.4.0-alpha.wasm';

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,3 @@
+/** The default URL for the LNC WASM client binary. */
+export const WASM_CLIENT_URL =
+  'https://lightning.engineering/lnc-v0.3.6-alpha.wasm';

--- a/lib/lightningNodeConnect.ts
+++ b/lib/lightningNodeConnect.ts
@@ -7,6 +7,7 @@ import {
   TaprootAssetsApi
 } from '@lightninglabs/lnc-core';
 import { createRpc } from './api/createRpc';
+import { WASM_CLIENT_URL } from './constants';
 import { PasskeyEncryptionService } from './encryption/passkeyEncryptionService';
 import SessionManager from './sessions/sessionManager';
 import { AuthenticationCoordinator } from './stores/authenticationCoordinator';
@@ -39,7 +40,7 @@ type ResolvedConfig = Required<
 
 /** The default values for the LightningNodeConnectConfig options. */
 export const DEFAULT_CONFIG: LightningNodeConnectConfig = {
-  wasmClientCode: 'https://lightning.engineering/lnc-v0.3.6-alpha.wasm',
+  wasmClientCode: WASM_CLIENT_URL,
   namespace: 'default',
   serverHost: 'mailbox.terminal.lightning.today:443',
   allowPasskeys: true,

--- a/lib/lnc.ts
+++ b/lib/lnc.ts
@@ -7,13 +7,14 @@ import {
   TaprootAssetsApi
 } from '@lightninglabs/lnc-core';
 import { createRpc } from './api/createRpc';
+import { WASM_CLIENT_URL } from './constants';
 import { CredentialStore, LncConfig } from './types/lnc';
 import LncCredentialStore from './util/credentialStore';
 import { ConnectionParams, WasmManager } from './wasmManager';
 
 /** The default values for the LncConfig options. */
 export const DEFAULT_CONFIG = {
-  wasmClientCode: 'https://lightning.engineering/lnc-v0.3.6-alpha.wasm',
+  wasmClientCode: WASM_CLIENT_URL,
   namespace: 'default',
   serverHost: 'mailbox.terminal.lightning.today:443'
 } as Required<LncConfig>;

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "webpack-cli": "5.1.4"
   },
   "dependencies": {
-    "@lightninglabs/lnc-core": "^0.3.6-alpha",
+    "@lightninglabs/lnc-core": "0.4.0-alpha",
     "crypto-js": "4.2.0"
   },
   "browser": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightninglabs/lnc-web",
-  "version": "0.3.6-alpha",
+  "version": "0.4.0-alpha",
   "description": "Lightning Node Connect npm module for web",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -351,10 +351,10 @@
   resolved "https://registry.yarnpkg.com/@lightninglabs/ai-docs-sync/-/ai-docs-sync-0.1.0.tgz#6f1fd672d50d0ad00238b0fa7eab8c4496ebda88"
   integrity sha512-u3CRCuMLaFDFvMCQT/aPgNcPYxVy8/bfp/uV8f1Z9C/KSz3YuJYh2KPTonmTen+KV/lm5B3a7kGjKWGYteEE5g==
 
-"@lightninglabs/lnc-core@^0.3.6-alpha":
-  version "0.3.6-alpha"
-  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-core/-/lnc-core-0.3.6-alpha.tgz#43cf66c6134cbc6edfcf55c857cc32c2a9ee825d"
-  integrity sha512-ObzY5wi+PS0GQduFHYDjGJpYZxKD27vtMf3fUVne2gGNMej1mvvJAOwATgef8YV/IZodAzy73Z/F2zfaQ+iE4Q==
+"@lightninglabs/lnc-core@0.4.0-alpha":
+  version "0.4.0-alpha"
+  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-core/-/lnc-core-0.4.0-alpha.tgz#8796109096ee21e8284954668c549a4ad091d2ae"
+  integrity sha512-7ODYXwJa6qgGh6e0ugVOo12hX8M8gcFjdcwljp3hdb3aGDefDRwsGwIqvloLm9tC/ZI/lyz+9HTCXG2jAuHXBQ==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -3252,8 +3252,16 @@ stream-http@^3.2.0:
     readable-stream "^3.6.0"
     xtend "^4.0.2"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
-  name string-width-cjs
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3285,8 +3293,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  name strip-ansi-cjs
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
This PR bumps the version to v0.4.0-alpha and also updates the wasm url to use v0.4.0-alpha.

This PR does not yet update the lnc-core dependency to v0.4.0-alpha, as it has not yet been released. I'll update this PR with a commit that updates the lnc-core dependency as soon as it has been released.

I'm therefore pushing this as draft until lnc-core has been released. As also communicated in the LNC-core PR, I haven't been able to fully test this yet due to issues with my local regtest env.