### PR TITLE
Add disconnect option to clear()

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,16 +327,21 @@ lnc.clear();
 // Forget this node - clears session AND long-term stored credentials.
 // User will need to pair again with a new phrase.
 lnc.clear({ persisted: true });
+
+// Full logout - clears credentials AND tears down the active WASM connection
+// in a single call, equivalent to calling clear() followed by disconnect().
+lnc.clear({ persisted: true, disconnect: true });
 ```
 
 `clear()` options:
 
-| Option      | Default | Description                                              |
-| ----------- | ------- | -------------------------------------------------------- |
-| `session`   | `true`  | Clear the short-term session from `sessionStorage`       |
-| `persisted` | `false` | Clear long-term credentials from `localStorage` / IndexedDB |
+| Option       | Default | Description                                                  |
+| ------------ | ------- | ------------------------------------------------------------ |
+| `session`    | `true`  | Clear the short-term session from `sessionStorage`           |
+| `persisted`  | `false` | Clear long-term credentials from `localStorage` / IndexedDB  |
+| `disconnect` | `false` | Also tear down the active WASM connection (same as calling `disconnect()`) |
 
-> **Note:** `clear()` only removes stored credentials — it does not tear down the active WASM connection. To fully disconnect, perform a page reload after clearing (e.g. `window.location.reload()`).
+> **Note:** By default, `clear()` only removes stored credentials — it does not tear down the active WASM connection. Pass `{ disconnect: true }` to also disconnect, or call `disconnect()` separately.
 
 ## Status Properties
 

--- a/lib/lightningNodeConnect.test.ts
+++ b/lib/lightningNodeConnect.test.ts
@@ -715,6 +715,22 @@ describe('LightningNodeConnect', () => {
       expect(mocks.authCoordinator.clearSession).not.toHaveBeenCalled();
       expect(mocks.strategyManager.clearAll).toHaveBeenCalled();
     });
+
+    it('does not disconnect by default', () => {
+      const lnc = new LightningNodeConnect();
+      const mocks = createModernMockSetup(lnc);
+      lnc.clear({ persisted: true });
+      expect(mocks.wasmManager.disconnect).not.toHaveBeenCalled();
+    });
+
+    it('disconnects when disconnect: true', () => {
+      const lnc = new LightningNodeConnect();
+      const mocks = createModernMockSetup(lnc);
+      lnc.clear({ persisted: true, disconnect: true });
+      expect(mocks.authCoordinator.clearSession).toHaveBeenCalled();
+      expect(mocks.strategyManager.clearAll).toHaveBeenCalled();
+      expect(mocks.wasmManager.disconnect).toHaveBeenCalled();
+    });
   });
 
   describe('getAuthenticationInfo', () => {

--- a/lib/lightningNodeConnect.ts
+++ b/lib/lightningNodeConnect.ts
@@ -396,10 +396,14 @@ export default class LightningNodeConnect {
   /**
    * Clear credentials. By default clears session data only.
    * Pass `{ persisted: true }` to also clear long-term stored credentials.
+   * Pass `{ disconnect: true }` to also tear down the active WASM connection
+   * (equivalent to calling `disconnect()`) — a full logout is
+   * `clear({ persisted: true, disconnect: true })`.
    */
   clear(options?: ClearOptions): void {
     const clearSession = options?.session !== false;
     const clearPersisted = options?.persisted === true;
+    const shouldDisconnect = options?.disconnect === true;
 
     if (clearSession) {
       this._authCoordinator.clearSession();
@@ -407,6 +411,10 @@ export default class LightningNodeConnect {
 
     if (clearPersisted) {
       this._strategyManager.clearAll();
+    }
+
+    if (shouldDisconnect) {
+      this.disconnect();
     }
   }
 

--- a/lib/types/lightningNodeConnect.ts
+++ b/lib/types/lightningNodeConnect.ts
@@ -94,6 +94,8 @@ export interface ClearOptions {
   session?: boolean;
   /** clear the long-term pairing credentials saved in local storage (default: false) */
   persisted?: boolean;
+  /** also tear down the active WASM connection, equivalent to calling disconnect() (default: false) */
+  disconnect?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes #189.

`clear()` only clears credential state (session/persisted) — it never tears down the active WASM connection. Doing a full logout today requires calling both `clear()` and `disconnect()` separately, and nothing in the method name or `ClearOptions` type signals that. The README's "Clearing Credentials" section works around this by recommending a full `window.location.reload()`.

This PR adds an explicit `disconnect: boolean` field to `ClearOptions` (default `false`, so existing behavior is unchanged):

```ts
// Full logout in one call
lnc.clear({ persisted: true, disconnect: true });
```

Went with the non-breaking option from the issue discussion (adding a flag) rather than making `clear()` disconnect by default, since the latter would silently change behavior for existing callers of a widely-used public method.

## Changes
- `lib/types/lightningNodeConnect.ts`: add `disconnect?: boolean` to `ClearOptions`
- `lib/lightningNodeConnect.ts`: `clear()` calls `this.disconnect()` when `disconnect: true`
- `lib/lightningNodeConnect.test.ts`: tests for default (no disconnect) and `disconnect: true` behavior
- `README.md`: document the new option and the full-logout pattern

## Test plan
- [x] `npx vitest run` — all 719 tests pass (2 new tests added)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — clean